### PR TITLE
Fix bug that prevents AAS models >20MB to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ dt-management.kafka.thread.count=1
 # Hostname used to start the MQTT server on
 dt-management.events.mqtt.host=localhost
 
+# Maximum MQTT message size. Default 256MB (max allowed according to MQTT specification)
+dt-management.events.mqtt.max-message-size:268435456
+
 # Port used to start the MQTT server on
 dt-management.events.mqtt.port=1883
 

--- a/src/main/java/eu/modapto/digitaltwinmanagement/config/DigitalTwinManagementConfig.java
+++ b/src/main/java/eu/modapto/digitaltwinmanagement/config/DigitalTwinManagementConfig.java
@@ -76,7 +76,7 @@ public class DigitalTwinManagementConfig {
     @Value("${dt-management.events.mqtt.port:1883}")
     private int mqttPort;
 
-    @Value("${dt-management.events.mqtt.max-message-size:10485760}")
+    @Value("${dt-management.events.mqtt.max-message-size:268435456}")
     private long mqttMaxMessageSize;
 
     @Value("${dt-management.events.mqtt.queue.size:100}")

--- a/src/main/java/eu/modapto/digitaltwinmanagement/config/ObjectMapperConfig.java
+++ b/src/main/java/eu/modapto/digitaltwinmanagement/config/ObjectMapperConfig.java
@@ -14,6 +14,7 @@
  */
 package eu.modapto.digitaltwinmanagement.config;
 
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.json.JsonMapperFactory;
@@ -28,8 +29,14 @@ public class ObjectMapperConfig {
     @Bean
     @Primary
     public ObjectMapper objectMapper() {
-        return new JsonMapperFactory()
+        ObjectMapper result = new JsonMapperFactory()
                 .create(new SimpleAbstractTypeResolverFactory().create())
                 .registerModule(new JavaTimeModule());
+        StreamReadConstraints streamReadConstraints = StreamReadConstraints
+                .builder()
+                .maxStringLength(Integer.MAX_VALUE)
+                .build();
+        result.getFactory().setStreamReadConstraints(streamReadConstraints);
+        return result;
     }
 }

--- a/src/main/java/eu/modapto/digitaltwinmanagement/deployment/DigitalTwinConnector.java
+++ b/src/main/java/eu/modapto/digitaltwinmanagement/deployment/DigitalTwinConnector.java
@@ -14,8 +14,10 @@
  */
 package eu.modapto.digitaltwinmanagement.deployment;
 
+import de.fraunhofer.iosb.ilt.faaast.service.config.CoreConfig;
 import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.HttpEndpointConfig;
 import de.fraunhofer.iosb.ilt.faaast.service.messagebus.mqtt.MessageBusMqttConfig;
+import de.fraunhofer.iosb.ilt.faaast.service.model.validation.ModelValidatorConfig;
 import eu.modapto.digitaltwinmanagement.config.DigitalTwinManagementConfig;
 import eu.modapto.digitaltwinmanagement.util.IdHelper;
 import eu.modapto.dt.faaast.service.smt.simulation.SimulationSubmodelTemplateProcessorConfig;
@@ -29,6 +31,13 @@ public abstract class DigitalTwinConnector {
     protected DigitalTwinConnector(DigitalTwinManagementConfig config, DigitalTwinConfig dtConfig) {
         this.config = config;
         this.dtConfig = dtConfig;
+    }
+
+
+    protected CoreConfig getCoreConfig() {
+        return CoreConfig.builder()
+                .validationOnLoad(ModelValidatorConfig.NONE)
+                .build();
     }
 
 

--- a/src/main/java/eu/modapto/digitaltwinmanagement/deployment/DigitalTwinConnectorDocker.java
+++ b/src/main/java/eu/modapto/digitaltwinmanagement/deployment/DigitalTwinConnectorDocker.java
@@ -176,6 +176,7 @@ public class DigitalTwinConnectorDocker extends DigitalTwinConnector {
 
     private void writeConfigFile() {
         ServiceConfig serviceConfig = ServiceConfig.builder()
+                .core(getCoreConfig())
                 .endpoint(getHttpEndpointConfig(CONTAINER_HTTP_PORT_INTERNAL))
                 .messageBus(getMessageBusMqttConfig())
                 .submodelTemplateProcessor(getSimulationSubmodelTemplateProcessorConfig())

--- a/src/main/java/eu/modapto/digitaltwinmanagement/deployment/DigitalTwinConnectorInternal.java
+++ b/src/main/java/eu/modapto/digitaltwinmanagement/deployment/DigitalTwinConnectorInternal.java
@@ -36,6 +36,7 @@ public class DigitalTwinConnectorInternal extends DigitalTwinConnector {
     public DigitalTwinConnectorInternal(DigitalTwinManagementConfig config, DigitalTwinConfig dtConfig) throws Exception {
         super(config, dtConfig);
         service = new Service(ServiceConfig.builder()
+                .core(getCoreConfig())
                 .endpoint(getHttpEndpointConfig(dtConfig.getHttpPort()))
                 .messageBus(getMessageBusMqttConfig())
                 .submodelTemplateProcessor(getSimulationSubmodelTemplateProcessorConfig())


### PR DESCRIPTION
* disable Jackson limitation for string properties >20MB (as whole AAS is serialized as single JSON property in HTTP request)
* disable duplicate AAS model validation in DT (as it already happens in DTM) to improve performance
* increase max MQTT message size to 256MB (which is the maximum for MQTT)